### PR TITLE
DM-47924: add overlay for dc2_test_med_1 repo

### DIFF
--- a/kubernetes/overlays/prod-dc2-test-med-1/Makefile
+++ b/kubernetes/overlays/prod-dc2-test-med-1/Makefile
@@ -1,0 +1,21 @@
+SECRET_PATH ?= secret/rubin/usdf-ingestd
+ENV = $(notdir ${CURDIR})
+
+get-secrets-from-vault:
+	mkdir -p etc/.secrets/
+	set -e; for i in user password; do vault kv get --field=$$i ${SECRET_PATH}/${ENV}/postgres > etc/.secrets/$$i ; done
+
+clean-secrets:
+	rm -rf etc/.secrets/
+
+run-dump:
+	kubectl kustomize .
+
+dump: get-secrets-from-vault run-dump clean-secrets
+
+run-apply:
+	kubectl apply -k .
+
+apply: get-secrets-from-vault run-apply clean-secrets
+
+

--- a/kubernetes/overlays/prod-dc2-test-med-1/ingestd.yml
+++ b/kubernetes/overlays/prod-dc2-test-med-1/ingestd.yml
@@ -1,0 +1,10 @@
+brokers: 134.79.23.221:9094
+group_id: "prod-dc2-test-med-1"
+num_messages: 50
+butler:
+  instrument: lsst.obs.lsst.LsstCamImSim
+  repo: /sdf/data/rubin/repo/dc2_test_med_1
+rses:
+  SLAC_BUTLER_DISK:
+    rucio_prefix: davs://sdfdtn005.slac.stanford.edu:1094/lsst/butlerdisk/rucio/repo/dc2_test_med_1/
+    fs_prefix: ""

--- a/kubernetes/overlays/prod-dc2-test-med-1/ingestd.yml
+++ b/kubernetes/overlays/prod-dc2-test-med-1/ingestd.yml
@@ -1,4 +1,4 @@
-brokers: 134.79.23.221:9094
+brokers: 134.79.23.189:9094
 group_id: "prod-dc2-test-med-1"
 num_messages: 50
 butler:

--- a/kubernetes/overlays/prod-dc2-test-med-1/kustomization.yaml
+++ b/kubernetes/overlays/prod-dc2-test-med-1/kustomization.yaml
@@ -1,0 +1,23 @@
+images:
+- name: ghcr.io/lsst-dm/ctrl_ingestd
+  newTag: "1.4"
+
+namespace: prod-dc2-test-med-1
+
+replicas:
+- name: ingestd
+  count: 1
+
+resources:
+- ../../common
+- ns.yaml
+
+configMapGenerator:
+- name: ingestd-config
+  files:
+  - ingestd.yml
+secretGenerator:
+- name: postgres
+  files:
+  - postgres-user=etc/.secrets/user
+  - postgres-password=etc/.secrets/password

--- a/kubernetes/overlays/prod-dc2-test-med-1/ns.yaml
+++ b/kubernetes/overlays/prod-dc2-test-med-1/ns.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: "prod-dc2-test-med-1"


### PR DESCRIPTION
Add overlay to handle the dc2_test_med_1 repo at FRDF so that files may be declared to dc2_test_med_1 scope and transfered back to USDF (i.e. for plots and ResourceUsageSummary)